### PR TITLE
Static initialization crash fix on Linux 64 bit

### DIFF
--- a/src/server/scripts/EasternKingdoms/gilneas.cpp
+++ b/src/server/scripts/EasternKingdoms/gilneas.cpp
@@ -145,7 +145,7 @@ public:
 ######*/
 
 uint32 guid_panicked_nextsay = 0; //GUID of the Panicked Citizen that will say random text, this is to prevent more than 1 npc speaking
-uint32 tSay_panicked = DELAY_SAY_PANICKED_CITIZEN; //Time left to say
+uint32 tSay_panicked = 30000; //Time left to say
 class npc_panicked_citizen : public CreatureScript
 {
 public:


### PR DESCRIPTION
Details are in the commit message.
This fixes crashes for me on Linux/GCC, but always worked with MSVC.

From the ACE_TSS docs:
- @note Beware when creating static instances of this type
- (as with any other, btw). The unpredictable order of initialization
- across different platforms may cause a situation where one uses
- the instance before it is fully initialized. That's why typically
- instances of this type are dynamicaly allocated. On the stack it is
- typically allocated inside the ACE_Thread::svc() method which
- limits its lifetime appropriately.
