### PR TITLE
Fix 3 ticket commands

### DIFF
--- a/src/server/game/Chat/Commands/TicketCommands.cpp
+++ b/src/server/game/Chat/Commands/TicketCommands.cpp
@@ -374,7 +374,7 @@ bool ChatHandler::HandleGMTicketEscalateCommand(const char *args)
 
     uint32 ticketId = atoi(args);
     GmTicket* ticket = sTicketMgr->GetTicket(ticketId);
-    if (!ticket || !ticket->IsClosed() || ticket->IsCompleted() || ticket->GetEscalatedStatus() != TICKET_UNASSIGNED)
+    if (!ticket || ticket->IsClosed() || ticket->IsCompleted() || ticket->GetEscalatedStatus() != TICKET_UNASSIGNED)
     {
         SendSysMessage(LANG_COMMAND_TICKETNOTEXIST);
         return true;
@@ -397,7 +397,7 @@ bool ChatHandler::HandleGMTicketCompleteCommand(const char* args)
 
     uint32 ticketId = atoi(args);
     GmTicket* ticket = sTicketMgr->GetTicket(ticketId);
-    if (!ticket || !ticket->IsClosed() || ticket->IsCompleted())
+    if (!ticket || ticket->IsClosed() || ticket->IsCompleted())
     {
         SendSysMessage(LANG_COMMAND_TICKETNOTEXIST);
         return true;
@@ -424,7 +424,7 @@ inline bool ChatHandler::_HandleGMTicketResponseAppendCommand(const char* args, 
         return false;
 
     GmTicket* ticket = sTicketMgr->GetTicket(ticketId);
-    if (!ticket || !ticket->IsClosed())
+    if (!ticket || ticket->IsClosed())
     {
         PSendSysMessage(LANG_COMMAND_TICKETNOTEXIST);
         return true;


### PR DESCRIPTION
3 commands were throwing errors if the ticket was not closed, when it should be if it IS closed
