### PR TITLE
Added Necrotic strike calc to a spellscript. Hack to CalcHealAbsorb is needed atm.

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -38,6 +38,56 @@ enum DeathKnightSpells
     DK_SPELL_IMPROVED_UNHOLY_PRESENCE_TRIGGERED = 63622,
 };
 
+class spell_dk_necrotic_strike : public SpellScriptLoader
+{
+public:
+    spell_dk_necrotic_strike() : SpellScriptLoader("spell_dk_necrotic_strike") { }
+
+    class spell_dk_necrotic_strike_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_dk_necrotic_strike_SpellScript);
+
+        enum Spells
+        {
+            DK_SPELL_NECROTIC_STRIKE = 73975,
+        };
+
+        bool Validate(SpellEntry const * /*spellEntry*/)
+        {
+            return sSpellStore.LookupEntry(DK_SPELL_NECROTIC_STRIKE);
+        }
+
+        void HandleAfterHit()
+        {
+    		Unit* caster = GetCaster();
+
+            if (Unit* target = GetHitUnit())
+            {
+				if (!target)//
+					return;
+					int32 nsbp = caster->GetTotalAttackPowerValue(BASE_ATTACK) * 0.75f;//initial scale
+					int32 getheal = target->GetAbsorbHeal();//Get current absorb value if any
+					int32 heal = nsbp + getheal;//define &| combine values
+
+				if (Aura* NS = target->GetAura(73975))
+				{
+					target->SetAbsorbHeal(heal);//set absorb value
+				}
+			}
+        }
+
+        void Register()
+        {
+			AfterHit += SpellHitFn(spell_dk_necrotic_strike_SpellScript::HandleAfterHit);
+        }
+    };
+
+    SpellScript *GetSpellScript() const
+    {
+        return new spell_dk_necrotic_strike_SpellScript();
+    }
+};
+
 // 50462 - Anti-Magic Shell (on raid member)
 class spell_dk_anti_magic_shell_raid : public SpellScriptLoader
 {
@@ -538,6 +588,7 @@ class spell_dk_chains_of_ice : public SpellScriptLoader
 
 void AddSC_deathknight_spell_scripts()
 {
+    new spell_dk_necrotic_strike();    
     new spell_dk_anti_magic_shell_raid();
     new spell_dk_anti_magic_shell_self();
     new spell_dk_anti_magic_zone();


### PR DESCRIPTION
basic script to calculate/set the absorb amount. The modifications to CalcHealAbsorb are needed atm. If anyone has a better workaround I would love to see.
