### PR TITLE
[Scripts] Loading. check already loaded script name for curent spell.

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -4872,12 +4872,30 @@ void ObjectMgr::LoadSpellScriptNames()
             }
             while (spellInfo)
             {
-                _spellScriptsStore.insert(SpellScriptsContainer::value_type(spellInfo->Id, GetScriptId(scriptName)));
+                bool found = false;
+                SpellScriptsBounds bounds = GetSpellScriptsBounds(spellInfo->Id);
+                for (SpellScriptsContainer::iterator itr = bounds.first; itr != bounds.second; ++itr)
+                    if (itr->second == GetScriptId(scriptName))
+                        found = true;
+                if (!found)
+                    _spellScriptsStore.insert(SpellScriptsContainer::value_type(spellInfo->Id, GetScriptId(scriptName)));
+                else
+                    sLog->outErrorDb("Scriptname:`%s` spell (spell_id:%d) already added.", scriptName, spellInfo->Id);
                 spellInfo = sSpellMgr->GetSpellInfo(spellInfo->Id)->GetNextRankSpell();
             }
         }
         else
-            _spellScriptsStore.insert(SpellScriptsContainer::value_type(spellInfo->Id, GetScriptId(scriptName)));
+        {
+            bool found = false;
+            SpellScriptsBounds bounds = GetSpellScriptsBounds(spellInfo->Id);
+            for (SpellScriptsContainer::iterator itr = bounds.first; itr != bounds.second; ++itr)
+                if (itr->second == GetScriptId(scriptName))
+                    found = true;
+            if (!found)
+                _spellScriptsStore.insert(SpellScriptsContainer::value_type(spellInfo->Id, GetScriptId(scriptName)));
+            else
+                sLog->outErrorDb("Scriptname:`%s` spell (spell_id:%d) already added.", scriptName, fields[0].GetInt32());
+        }
         ++count;
     }
     while (result->NextRow());


### PR DESCRIPTION
privent duble addding scripts.
- Fix problems with current db where abount 20 spell are double added. Fix help us to find this scipts and privent load it second time.
  System could add one script twice. One when he added with positive int, and second  as spell chain.

Of couse if we add twice script it will be caled twice. Problems -> MEGA-DAMAGE (for example) because our methods of calc damage chenge original spelld damage. 
