### PR TITLE
Compile fix

### DIFF
--- a/src/tools/vmap3_extractor/CMakeLists.txt
+++ b/src/tools/vmap3_extractor/CMakeLists.txt
@@ -35,9 +35,9 @@ endif ()
 add_executable(vmap3extractor ${sources})
 
 target_link_libraries(vmap3extractor
+  mpq
   ${BZIP2_LIBRARIES}
   ${ZLIB_LIBRARIES}
-  mpq
 )
 
 add_dependencies(vmap3extractor mpq)


### PR DESCRIPTION
Fixed an issue where vmap3_extractor will not compile on Ubuntu 12.04 due to link order.
