### PR TITLE
Pets crashfix attempt

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -9980,19 +9980,19 @@ void Unit::SetMinion(Minion *minion, bool apply, PetSlot slot)
 
         if (GetTypeId() == TYPEID_PLAYER)
         {
-            // If its not a Hunter Pet, only set pet slot. use setPetSlotUsed only for hunter pets.
-            // Always save thoose spots where hunter is correct
-            if (!minion->isHunterPet())
-                ToPlayer()->_currentPetSlot = slot;
-            else if (slot >= PET_SLOT_HUNTER_FIRST && slot <= PET_SLOT_HUNTER_LAST)
+            // If its a Hunter Pet, set pet slot and setPetSlotUsed.
+            if (minion->isHunterPet())
             {
-                ToPlayer()->_currentPetSlot = slot;
-                ToPlayer()->setPetSlotUsed(slot, true);
-            }
-            else
-            {
-                sLog->outCrash("Unit::SetMinion. Try to add hunter pet to not alawed slot(%u). Minion %u for %u", slot, minion->GetEntry(), ToPlayer()->GetEntry());
-                ASSERT(false);
+                if (slot >= PET_SLOT_HUNTER_FIRST && slot <= PET_SLOT_HUNTER_LAST)
+                {
+                    ToPlayer()->_currentPetSlot = slot;
+                    ToPlayer()->setPetSlotUsed(slot, true);
+                }
+                else
+                {
+                    sLog->outCrash("Unit::SetMinion. Tried to add hunter pet to not allowed slot (%u). Minion %u for %u", slot, minion->GetEntry(), ToPlayer()->GetEntry());
+                    ASSERT(false);
+                }
             }
         }
         if (minion->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))


### PR DESCRIPTION
Change Unit::SetMinion to only ever overwrite the _currentPetSlot if the minion is a Hunter pet.
Fixes the issue with saving and crashing pets, and doesn't seem to affect non-hunter pets and minions.
If you can think of a problem this causes, you can let me know :)
