### PR TITLE
FreeBSD Compile Fix

### DIFF
--- a/dep/g3dlite/source/FileSystem.cpp
+++ b/dep/g3dlite/source/FileSystem.cpp
@@ -27,6 +27,13 @@
 #   include <io.h>
 
 #define stat64 _stat64
+#elif defined(__FreeBSD__)
+#   include <dirent.h>
+#   include <fnmatch.h>
+#   include <unistd.h>
+#   define _stat stat
+#   define _getcwd getcwd
+#   define stat64 stat
 #else
 #   include <dirent.h>
 #   include <fnmatch.h>

--- a/src/tools/extractor/StormLib/src/FileStream.cpp
+++ b/src/tools/extractor/StormLib/src/FileStream.cpp
@@ -14,6 +14,13 @@
 /*****************************************************************************/
 
 #define __STORMLIB_SELF__
+#if defined __FreeBSD__
+#   define O_LARGEFILE      0100000
+#   define off64_t off_t 
+#   define lseek64 lseek 
+#   define fstat64 fstat 
+#   define stat64 stat
+#endif
 #include "StormLib.h"
 #include "StormCommon.h"
 

--- a/src/tools/vmap3_extractor/model.h
+++ b/src/tools/vmap3_extractor/model.h
@@ -21,6 +21,9 @@
 #ifndef MODEL_H
 #define MODEL_H
 
+#if defined __FreeBSD__
+#   include <stdio.h>
+#endif
 #include "loadlib/loadlib.h"
 #include "vec3d.h"
 //#include "mpq.h"

--- a/src/tools/vmap3_extractor/wmo.h
+++ b/src/tools/vmap3_extractor/wmo.h
@@ -25,6 +25,9 @@
 
 #include <string>
 #include <set>
+#if defined __FreeBSD__
+#   include <stdio.h>
+#endif
 #include "vec3d.h"
 #include "loadlib/loadlib.h"
 


### PR DESCRIPTION
Fixed several definitions causing compiling erros on FreeBSD.

Successfully build on FreeBSD @ June 22 2012

dep/g3dlite/source/FileSystem.cpp
-> dep/g3dlite/source/FileSystem.cpp:499: error: aggregate 'G3D::stat64 st' has incomplete type and cannot be defined 

src/tools/extractor/StormLib/src/FileStream.cpp
-> src/tools/extractor/StormLib/src/FileStream.cpp:327: error: 'O_LARGEFILE' was not declared in this scope
-> src/tools/extractor/StormLib/src/FileStream.cpp:507: error: 'off64_t' was not declared in this scope
-> src/tools/extractor/StormLib/src/FileStream.cpp:507: error: 'lseek64' was not declared in this scope
-> src/tools/extractor/StormLib/src/FileStream.cpp:657: error: 'fstat64' was not declared in this scope
-> src/tools/extractor/StormLib/src/FileStream.cpp:662: error: aggregate 'stat64 fileinfo' has incomplete type and cannot be defined

src/tools/vmap3_extractor/wmo.h
-> src/tools/vmap3_extractor/wmo.h:59: error: 'FILE' has not been declared

src/tools/vmap3_extractor/model.h
-> src/tools/vmap3_extractor/model.h:69: error: 'FILE' has not been declared
