### PR TITLE
Fix medium quest bug - Death's Challenge

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -578,6 +578,7 @@ public:
                     {
                         doneBy->RemoveGameObject(SPELL_DUEL_FLAG, true);
                         doneBy->AttackStop();
+                        doneBy->getHostileRefManager().deleteReferences();
                         me->CastSpell(doneBy, SPELL_DUEL_VICTORY, true);
                         lose = true;
                         me->CastSpell(me, 7267, true);


### PR DESCRIPTION
After defeating your combat state remains and you are not able to duel any more initiates.
This causes the quest to be hard for completion. You need to fight some other creature, die or relog
in order to clear your combat state. Set to clear all threat references of the target player.
