### PR TITLE
Core/Build:

### DIFF
--- a/src/server/shared/Define.h
+++ b/src/server/shared/Define.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2011-2013 Project SkyFire <http://www.projectskyfire.org/>
  * Copyright (C) 2008-2013 TrinityCore <http://www.trinitycore.org/>
  * Copyright (C) 2005-2013 MaNGOS <http://getmangos.com/>
  *
@@ -74,10 +75,22 @@ typedef ACE_INT64 int64;
 typedef ACE_INT32 int32;
 typedef ACE_INT16 int16;
 typedef ACE_INT8 int8;
+#ifndef _UINT64 	// Fix for Mac OSX
 typedef ACE_UINT64 uint64;
+#define _UINT64
+#endif
+#ifndef _UINT32 	// Fix for Mac OSX
 typedef ACE_UINT32 uint32;
+#define _UINT32
+#endif
+#ifndef _UINT16 	// Fix for Mac OSX
 typedef ACE_UINT16 uint16;
+#define _UINT16
+#endif
+#ifndef _UINT8 		// Fix for Mac OSX
 typedef ACE_UINT8 uint8;
+#define _UINT8
+#endif
 
 enum DBCFormatRecord
 {


### PR DESCRIPTION
Fixed an issue that caused errors when compiling on Mac OS/X 
Types like uint64 are also defined in Security Framework on Mac OS/X. This causes type conflict errors during build. Added checks to prevent Security Framework from trying to define the same types again.

Original patcher: isair (http://tinyurl.com/commit-topic)

Signed-off-by: Image EmageDev@gmail.com
